### PR TITLE
Add a profiler based on async-profiler

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/infra/BenchmarkParams.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/infra/BenchmarkParams.java
@@ -31,6 +31,9 @@ import org.openjdk.jmh.util.Utils;
 import org.openjdk.jmh.util.Version;
 
 import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -446,6 +449,31 @@ abstract class BenchmarkParamsL2 extends BenchmarkParamsL1 implements Serializab
             sb.append(key).append("-").append(params.get(key));
         }
         return sb.toString();
+    }
+
+    /**
+     * @return a textual representation of these parameters suitable for use as a file name.
+     */
+    public String sanitizedId() {
+        StringBuilder sb = new StringBuilder();
+        appendSanitized(sb, benchmark);
+        sb.append("-");
+        sb.append(mode);
+        for (String key : params.keys()) {
+            sb.append("-");
+            appendSanitized(sb, key);
+            sb.append("-");
+            appendSanitized(sb, params.get(key));
+        }
+        return sb.toString();
+    }
+
+    private static void appendSanitized(StringBuilder builder, String s) {
+        try {
+            builder.append(URLEncoder.encode(s, StandardCharsets.UTF_8.name()));
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/AbstractPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/AbstractPerfAsmProfiler.java
@@ -598,7 +598,7 @@ public abstract class AbstractPerfAsmProfiler implements ExternalProfiler {
          */
         if (savePerfOutput) {
             String target = (savePerfOutputToFile == null) ?
-                savePerfOutputTo + "/" + br.getParams().id() + ".perf" :
+                savePerfOutputTo + "/" + br.getParams().sanitizedId() + ".perf" :
                 savePerfOutputToFile;
             try {
                 FileUtils.copy(perfParsedData.getAbsolutePath(), target);
@@ -613,7 +613,7 @@ public abstract class AbstractPerfAsmProfiler implements ExternalProfiler {
          */
         if (savePerfBin) {
             String target = (savePerfBinFile == null) ?
-                savePerfBinTo + "/" + br.getParams().id() + perfBinaryExtension() :
+                savePerfBinTo + "/" + br.getParams().sanitizedId() + perfBinaryExtension() :
                 savePerfBinFile;
             try {
                 FileUtils.copy(perfBinData.getAbsolutePath(), target);
@@ -628,7 +628,7 @@ public abstract class AbstractPerfAsmProfiler implements ExternalProfiler {
          */
         if (saveLog) {
             String target = (saveLogToFile == null) ?
-                saveLogTo + "/" + br.getParams().id() + ".log" :
+                saveLogTo + "/" + br.getParams().sanitizedId() + ".log" :
                 saveLogToFile;
             try (FileOutputStream asm = new FileOutputStream(target);
                  PrintWriter pwAsm = new PrintWriter(asm)) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/AsyncProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/AsyncProfiler.java
@@ -1,0 +1,473 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.profile;
+
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+import joptsimple.HelpFormatter;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.IterationParams;
+import org.openjdk.jmh.results.BenchmarkResult;
+import org.openjdk.jmh.results.IterationResult;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.TextResult;
+import org.openjdk.jmh.runner.IterationType;
+
+import java.io.*;
+import java.util.*;
+
+
+/**
+ * A profiler based on <a href="https://github.com/jvm-profiling-tools/async-profiler/commits/master">async-profiler</a>.
+ *
+ * @author Jason Zaugg
+ */
+public final class AsyncProfiler implements ExternalProfiler, InternalProfiler {
+  private static final String DEFAULT_EVENT = "cpu";
+
+  private final JavaApi instance;
+
+  private final boolean verbose;
+  private final Direction direction;
+  private final String profilerConfig;
+  private final List<OutputType> output;
+  private final String event;
+  private final File outDir;
+  private final int traces;
+  private final int flat;
+
+  private boolean warmupStarted = false;
+  private boolean measurementStarted = false;
+  private int measurementIterationCount = 0;
+  private final List<File> generated = new ArrayList<>();
+
+  public AsyncProfiler(String initLine) throws ProfilerException {
+    OptionParser parser = new OptionParser();
+
+    HelpFormatter formatter = new ProfilerOptionFormatter("async");
+
+    parser.formatHelpWith(formatter);
+
+    OptionSpec<OutputType> output = parser.accepts("output", "Output format(s)")
+        .withRequiredArg().ofType(OutputType.class).withValuesSeparatedBy(",").describedAs("format+").defaultsTo(OutputType.text);
+    OptionSpec<Direction> direction = parser.accepts("direction", "Direction(s) of flame graph")
+        .withRequiredArg().ofType(Direction.class).describedAs("direction").defaultsTo(Direction.both);
+
+    OptionSpec<String> libPath = parser.accepts("libPath", "Location of libasyncProfiler.so. " +
+        "If not specified, System.loadLibrary will be used and the library must be made available to the forked JVM " +
+        "in an entry of -Djava.library.path or LD_LIBRARY_PATH.")
+        .withRequiredArg().ofType(String.class).describedAs("path");
+
+    OptionSpec<String> event = parser.accepts("event", "Event to sample: cpu, alloc, wall, lock, cache-misses etc.")
+        .withRequiredArg().ofType(String.class).defaultsTo(DEFAULT_EVENT);
+    OptionSpec<String> dir = parser.accepts("dir", "Output directory.")
+        .withRequiredArg().ofType(String.class).describedAs("dir");
+    OptionSpec<Long> interval = parser.accepts("interval", "Profiling interval")
+        .withRequiredArg().ofType(Long.class).describedAs("ns");
+    OptionSpec<Integer> jstackdepth = parser.accepts("jstackdepth", "Maximum Java stack depth")
+        .withRequiredArg().ofType(Integer.class).describedAs("frames");
+    OptionSpec<Long> framebuf = parser.accepts("framebuf", "Size of profiler framebuffer")
+        .withRequiredArg().ofType(Long.class).describedAs("bytes");
+    OptionSpec<Boolean> threads = parser.accepts("threads", "Profile threads separately")
+        .withRequiredArg().ofType(Boolean.class).describedAs("int");
+    OptionSpec<Boolean> simple = parser.accepts("simple", "Simple class names instead of FQN")
+        .withRequiredArg().ofType(Boolean.class).describedAs("bool");
+    OptionSpec<Boolean> sig = parser.accepts("sig", "Print method signatures")
+        .withRequiredArg().ofType(Boolean.class).describedAs("bool");
+    OptionSpec<Boolean> ann = parser.accepts("ann", "Annotate Java method names")
+        .withRequiredArg().ofType(Boolean.class).describedAs("bool");
+    OptionSpec<String> include = parser.accepts("include", "output only stack traces containing the specified pattern")
+        .withRequiredArg()
+        .withValuesSeparatedBy(",").ofType(String.class).describedAs("regexp+");
+    OptionSpec<String> exclude = parser.accepts("exclude", "exclude stack traces with the specified pattern")
+        .withRequiredArg()
+        .withValuesSeparatedBy(",").ofType(String.class).describedAs("regexp+");
+    OptionSpec<String> rawCommand = parser.accepts("rawCommand", "Command to pass directly to async-profiler." +
+        " Use to access new features of JMH profiler that are not yet supported in this option parser.")
+        .withRequiredArg().ofType(String.class).describedAs("command");
+
+    OptionSpec<String> title = parser.accepts("title", "SVG title")
+        .withRequiredArg().ofType(String.class).describedAs("string");
+    OptionSpec<Long> width = parser.accepts("width", "SVG width")
+        .withRequiredArg().ofType(Long.class).describedAs("pixels");
+    OptionSpec<Long> minWidth = parser.accepts("minwidth", "skip frames smaller than px")
+        .withRequiredArg().ofType(Long.class).describedAs("pixels");
+
+    OptionSpec<Boolean> allKernel = parser.accepts("allkernel", "only include kernel-mode events")
+        .withRequiredArg().ofType(Boolean.class).describedAs("bool");
+    OptionSpec<Boolean> allUser = parser.accepts("alluser", "only include user-mode events")
+        .withRequiredArg().ofType(Boolean.class).describedAs("bool");
+    OptionSpec<CStackMode> cstack = parser.accepts("cstack", "how to traverse C stack")
+        .withRequiredArg().ofType(CStackMode.class).describedAs("bool");
+
+    OptionSpec<Boolean> verbose = parser.accepts("verbose", "Output the sequence of commands")
+        .withRequiredArg().ofType(Boolean.class).defaultsTo(false).describedAs("bool");
+
+    OptionSpec<Integer> traces = parser.accepts("traces", "Number of top traces to include in the default output")
+        .withRequiredArg().ofType(Integer.class).defaultsTo(200).describedAs("int");
+    OptionSpec<Integer> flat = parser.accepts("flat", "Number of top flat profiles to include in the default output")
+        .withRequiredArg().ofType(Integer.class).defaultsTo(200).describedAs("int");
+
+    OptionSet options = ProfilerUtils.parseInitLine(initLine, parser);
+
+    StringBuilder profilerOptions = new StringBuilder();
+
+    ProfilerOptionsBuilder builder = new ProfilerOptionsBuilder(options, profilerOptions);
+    this.event = event.value(options);
+    builder.append(event);
+    if (!options.has(dir)) {
+      String prefix = "jmh-async-profiler-";
+      outDir = createTempDir(prefix, null);
+    } else {
+      outDir = new File(options.valueOf(dir));
+    }
+
+    builder.appendIfExists(interval);
+    builder.appendIfExists(jstackdepth);
+    builder.appendIfTrue(threads);
+    builder.appendIfTrue(simple);
+    builder.appendIfTrue(sig);
+    builder.appendIfTrue(ann);
+    builder.appendIfExists(framebuf);
+    builder.appendMulti(include);
+    builder.appendMulti(exclude);
+
+    builder.appendIfExists(title);
+    builder.appendIfExists(width);
+    builder.appendIfExists(minWidth);
+
+    builder.appendIfTrue(allKernel);
+    builder.appendIfTrue(allUser);
+    builder.appendIfExists(cstack);
+
+    if (options.has(rawCommand)) {
+      builder.appendRaw(rawCommand.value(options));
+    }
+
+    this.traces = traces.value(options);
+    this.flat = flat.value(options);
+
+    this.profilerConfig = profilerOptions.toString();
+
+    if (options.has(libPath)) {
+      instance = JavaApi.getInstance(libPath.value(options));
+    } else {
+      instance = JavaApi.getInstance();
+    }
+    this.direction = direction.value(options);
+    this.output = output.values(options);
+    this.verbose = verbose.value(options);
+  }
+
+  @Override
+  public void beforeIteration(BenchmarkParams benchmarkParams, IterationParams iterationParams) {
+    if (iterationParams.getType() == IterationType.WARMUP) {
+      if (!warmupStarted) {
+        // Collect profiles during warmup to warmup the profiler itself.
+        execute("start," + profilerConfig);
+        warmupStarted = true;
+      }
+    }
+    if (iterationParams.getType() == IterationType.MEASUREMENT) {
+      if (!measurementStarted) {
+        // Discard samples collected during warmup and start collecting again.
+        execute("start," + profilerConfig);
+        measurementStarted = true;
+      }
+    }
+  }
+
+  @Override
+  public Collection<? extends Result> afterIteration(BenchmarkParams benchmarkParams, IterationParams iterationParams,
+                                                     IterationResult iterationResult) {
+    if (iterationParams.getType() == IterationType.MEASUREMENT) {
+      measurementIterationCount += 1;
+      if (measurementIterationCount == iterationParams.getCount()) {
+        File trialOutDir = createTrialOutDir(benchmarkParams);
+        return Collections.singletonList(stopAndDump(trialOutDir));
+      }
+    }
+
+    return Collections.emptyList();
+  }
+
+  private File createTrialOutDir(BenchmarkParams benchmarkParams) {
+    String fileName = benchmarkParams.sanitizedId();
+    File trialOutDir = new File(this.outDir, fileName);
+    trialOutDir.mkdirs();
+    return trialOutDir;
+  }
+
+  private TextResult stopAndDump(File trialOutDir) {
+    execute("stop");
+
+    StringWriter output = new StringWriter();
+    PrintWriter pw = new PrintWriter(output);
+    for (OutputType outputType : this.output) {
+      switch (outputType) {
+        case text:
+          String textOutput = dump(trialOutDir, "summary-%s.txt", "summary,flat=" + flat + ",traces=" + traces);
+          pw.println(textOutput);
+          break;
+        case collapsed:
+          dump(trialOutDir, "collapsed-%s.csv", "collapsed");
+          break;
+        case flamegraph:
+          if (direction == Direction.both || direction == Direction.forward) {
+            dump(trialOutDir, "flame-%s-forward.svg", "svg");
+          }
+          if (direction == Direction.both || direction == Direction.reverse) {
+            dump(trialOutDir, "flame-%s-reverse.svg", "svg,reverse");
+          }
+          break;
+        case tree:
+          dump(trialOutDir, "tree-%s.html", "tree");
+          break;
+        case jfr:
+          dump(trialOutDir, "%s.jfr", "jfr");
+          break;
+      }
+    }
+    for (File file : generated) {
+      pw.println(file.getAbsolutePath());
+    }
+    pw.flush();
+    pw.close();
+
+    return new TextResult(output.toString(), "async");
+  }
+
+  private String dump(File specificOutDir, String fileNameFormatString, String content) {
+    File output = new File(specificOutDir, String.format(fileNameFormatString, event));
+    generated.add(output);
+    String result = execute(content + "," + profilerConfig);
+    write(output, result);
+    return result;
+  }
+
+  private String execute(String command) {
+    if (verbose) {
+      System.out.println("[async-profiler] " + command);
+    }
+    try {
+      return instance.execute(command);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void write(File output, String s) {
+    try {
+      try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(output)))) {
+        writer.write(s);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static File createTempDir(String prefix, File dir) {
+    try {
+      File tempFile = File.createTempFile(prefix, "", dir);
+      tempFile.delete();
+      tempFile.mkdir();
+      return tempFile;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public enum CStackMode {
+    fp,
+    lbr,
+    no
+  }
+
+  public enum OutputType {
+    //NONE,
+    text,
+    collapsed,
+    flamegraph,
+    tree,
+    jfr
+  }
+
+  public enum Direction {
+    forward,
+    reverse,
+    both,
+  }
+
+  private static class ProfilerOptionsBuilder {
+    private final OptionSet optionSet;
+    private final StringBuilder profilerOptions;
+
+    ProfilerOptionsBuilder(OptionSet optionSet, StringBuilder profilerOptions) {
+      this.optionSet = optionSet;
+      this.profilerOptions = profilerOptions;
+    }
+
+    <T> void appendIfExists(OptionSpec<T> option) {
+      if (optionSet.has(option)) {
+        append(option);
+      }
+    }
+
+    <T> void append(OptionSpec<T> option) {
+      assert (option.options().size() == 1);
+      String optionName = option.options().iterator().next();
+      separate();
+      profilerOptions.append(optionName).append('=').append(optionSet.valueOf(option).toString());
+    }
+
+    void appendRaw(String command) {
+      separate();
+      profilerOptions.append(command);
+    }
+
+    private void separate() {
+      if (profilerOptions.length() > 0) {
+        profilerOptions.append(',');
+      }
+    }
+
+    void appendIfTrue(OptionSpec<Boolean> option) {
+      if (optionSet.has(option) && optionSet.valueOf(option)) {
+        append(option);
+      }
+    }
+
+    private <T> void appendMulti(OptionSpec<T> option) {
+      if (optionSet.has(option)) {
+        assert (option.options().size() == 1);
+        String optionName = option.options().iterator().next();
+        for (T value : optionSet.valuesOf(option)) {
+          profilerOptions.append(',').append(optionName).append('=').append(value.toString());
+        }
+      }
+    }
+  }
+
+  @Override
+  public Collection<String> addJVMInvokeOptions(BenchmarkParams params) {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Collection<String> addJVMOptions(BenchmarkParams params) {
+    List<String> args = new ArrayList<>();
+    args.add("-XX:+UnlockDiagnosticVMOptions");
+    // Recommended option for async-profiler, enable automatically.
+    args.add("-XX:+DebugNonSafepoints");
+    return args;
+  }
+
+  @Override
+  public void beforeTrial(BenchmarkParams benchmarkParams) {
+  }
+
+  @Override
+  public Collection<? extends Result> afterTrial(BenchmarkResult br, long pid, File stdOut, File stdErr) {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public boolean allowPrintOut() {
+    return true;
+  }
+
+  @Override
+  public boolean allowPrintErr() {
+    return true;
+  }
+
+  @Override
+  public String getDescription() {
+    return "async-profiler profiler provider.";
+  }
+
+  // Made public so that power-users could can call filterThread from within the workload
+  // to limit collection to a set of threads. This is useful for wall-clock profiling.
+  // Adding support in JMH to pass the threads to profilers seems like an invasive change for
+  // this niche use case.
+  public static final class JavaApi {
+    private static final Thread ALL_THREADS = null;
+    private static EnumSet<Thread.State> ignoredThreadStates = EnumSet.of(Thread.State.NEW, Thread.State.TERMINATED);
+    private static JavaApi INSTANCE;
+
+    public static JavaApi getInstance(String libraryFileName) {
+      if (INSTANCE == null) {
+        synchronized(AsyncProfiler.class) {
+          INSTANCE = new JavaApi(libraryFileName);
+        }
+      }
+      return INSTANCE;
+    }
+    public static JavaApi getInstance() {
+      if (INSTANCE == null) {
+        synchronized(AsyncProfiler.class) {
+          INSTANCE = new JavaApi();
+        }
+      }
+      return INSTANCE;
+    }
+
+    private JavaApi(String libraryFileName) {
+      System.load(libraryFileName);
+    }
+    private JavaApi() {
+      System.loadLibrary("libasyncProfiler");
+    }
+    public String execute(String command) throws IOException {
+      return execute0(command);
+    }
+
+    /**
+     * Enable or disable profile collection for threads.
+     *
+     * @param thread The thread to enable or disable. <code>null</code> is a wildcard.
+     * @param enable Whether to enable or disable.
+     */
+    public void filterThread(Thread thread, boolean enable) {
+      if (thread == ALL_THREADS) {
+        filterThread0(ALL_THREADS, enable);
+      } else {
+        synchronized (thread) {
+          Thread.State state = thread.getState();
+          if (!ignoredThreadStates.contains(state)) {
+            filterThread0(thread, enable);
+          }
+        }
+      }
+    }
+
+    // Loading async-profiler will automatically bind these native methods to the profiler implementation.
+    private native void start0(String event, long interval, boolean reset) throws IllegalStateException;
+    private native void stop0() throws IllegalStateException;
+    private native String execute0(String command) throws IllegalArgumentException, IOException;
+    private native void filterThread0(Thread thread, boolean enable);
+  }
+}

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/ProfilerFactory.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/ProfilerFactory.java
@@ -164,6 +164,7 @@ public class ProfilerFactory {
 
     static {
         BUILT_IN = new TreeMap<>();
+        BUILT_IN.put("async",    AsyncProfiler.class);
         BUILT_IN.put("cl",       ClassloaderProfiler.class);
         BUILT_IN.put("comp",     CompilerProfiler.class);
         BUILT_IN.put("gc",       GCProfiler.class);

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/ProfilerOptionFormatter.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/ProfilerOptionFormatter.java
@@ -31,7 +31,7 @@ import org.openjdk.jmh.util.Utils;
 import java.util.List;
 import java.util.Map;
 
-class ProfilerOptionFormatter implements HelpFormatter {
+public class ProfilerOptionFormatter implements HelpFormatter {
 
     private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/ProfilerUtils.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/ProfilerUtils.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.concurrent.TimeUnit;
 
-class ProfilerUtils {
+public class ProfilerUtils {
 
     public static OptionSet parseInitLine(String initLine, OptionParser parser) throws ProfilerException {
         parser.accepts("help", "Display help.");

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/ProfilersFailedException.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/ProfilersFailedException.java
@@ -24,11 +24,12 @@
  */
 package org.openjdk.jmh.runner;
 
+import org.openjdk.jmh.profile.ProfilerException;
+
 public class ProfilersFailedException extends RunnerException {
     private static final long serialVersionUID = 1446854343206595167L;
 
-    public String getMessage() {
-        return "Profilers failed to initialize, exiting.";
+    public ProfilersFailedException(ProfilerException e) {
+        super("Profilers failed to initialize, exiting.", e);
     }
-
 }


### PR DESCRIPTION
## Full set of options
```
[info] Usage: -prof <profiler-name>:opt1=value1,value2;opt2=value3
[info] Options accepted by async:
[info]   allkernel=<bool>                 only include kernel-mode events
[info]   alluser=<bool>                   only include user-mode events
[info]   ann=<bool>                       Annotate Java method names
[info]   asyncProfilerDir=<directory>     Path to build of of https://github.com/jvm-profiling-tools/async-profiler.
[info]                                    Can also be provided as an environment variable $ASYNC_PROFILER_DIR
[info]   cstack=<bool>                    how to traverse C stack
[info]   event=<>                         Event to sample: cpu, alloc, wall, lock, cache-misses
[info]                                    etc. (default: [cpu])
[info]   exclude=<regexp+>                exclude stack traces with the specified pattern
[info]   file=<file>                      Output file. '%p' and '%t' are expanded to the Process
[info]                                    ID and timestamp respectively. The output type is
[info]                                    determined by the extension, one of .collapsed (collapsed
[info]                                    stacks) / .svg (flamegraph) / .html (Tree) / .jfr
[info]                                    (Java Flight Recorder) / .txt stacks. If no file is
[info]                                    provided, the default output format is textual and
[info]                                    includes a summary, the top stacks and top methods.
[info]   flat=<int>                       Number of top flat profile to include in the default
[info]                                    output (default: [200])
[info]   framebuf=<bytes>                 Size of profiler framebuffer
[info]   help                             Display help.
[info]   include=<regexp+>                output only stack traces containing the specified
[info]                                    pattern
[info]   interval=<ns>                    Profiling interval
[info]   jstackdepth=<frames>             Maximum Java stack depth
[info]   minwidth=<pixels>                skip frames smaller than px
[info]   reverse=<bool>                   generate stack-reversed FlameGraph / Call tree
[info]   sig=<bool>                       Print method signatures
[info]   simple=<bool>                    Simple class names instead of FQN
[info]   threads=<int>                    Profile threads separately
[info]   title=<string>                   SVG title
[info]   traces=<int>                     Number of top traces to include in the default output
[info]                                    (default: [200])
[info]   verbose=<bool>                   Output the sequence of commands (default: [false])
[info]   width=<pixels>                   SVG width
```

## Generate textual output:

```
-prof "async:traces=2;flat=10"
...
[info] Secondary result "scala.tools.nsc.HotScalacBenchmark.compile:··async":
[info] --- Execution profile ---
[info] Total samples       : 6676
[info] unknown_Java        : 30 (0.45%)
[info] deoptimization      : 1 (0.01%)
[info] Frame buffer usage  : 27.8018%
[info] --- 1130000000 ns (1.69%), 113 samples
[info]   [ 0] PhaseChaitin::Split(unsigned int, ResourceArea*)
[info]   [ 1] PhaseChaitin::Register_Allocate()
[info]   [ 2] Compile::Code_Gen()
[info]   [ 3] Compile::Compile(ciEnv*, C2Compiler*, ciMethod*, int, bool, bool, bool, DirectiveSet*)
[info]   [ 4] C2Compiler::compile_method(ciEnv*, ciMethod*, int, DirectiveSet*)
[info]   [ 5] CompileBroker::invoke_compiler_on_method(CompileTask*)
[info]   [ 6] CompileBroker::compiler_thread_loop()
[info]   [ 7] JavaThread::thread_main_inner()
[info]   [ 8] JavaThread::run()
[info]   [ 9] Thread::call_run()
[info]   [10] thread_native_entry(Thread*)
[info]   [11] _pthread_start
[info]   [12] thread_start
[info] --- 860000000 ns (1.29%), 86 samples
[info]   [ 0] PhaseChaitin::elide_copy(Node*, int, Block*, Node_List&, Node_List&, bool)
[info]   [ 1] PhaseChaitin::post_allocate_copy_removal()
[info]   [ 2] PhaseChaitin::Register_Allocate()
[info]   [ 3] Compile::Code_Gen()
[info]   [ 4] Compile::Compile(ciEnv*, C2Compiler*, ciMethod*, int, bool, bool, bool, DirectiveSet*)
[info]   [ 5] C2Compiler::compile_method(ciEnv*, ciMethod*, int, DirectiveSet*)
[info]   [ 6] CompileBroker::invoke_compiler_on_method(CompileTask*)
[info]   [ 7] CompileBroker::compiler_thread_loop()
[info]   [ 8] JavaThread::thread_main_inner()
[info]   [ 9] JavaThread::run()
[info]   [10] Thread::call_run()
[info]   [11] thread_native_entry(Thread*)
[info]   [12] _pthread_start
[info]   [13] thread_start
[info]           ns  percent  samples  top
[info]   ----------  -------  -------  ---
[info]   1130000000    1.69%      113  PhaseChaitin::Split(unsigned int, ResourceArea*)
[info]   1120000000    1.68%      112  IndexSetIterator::advance_and_next()
[info]   1040000000    1.56%      104  Node::in(unsigned int) const
[info]    890000000    1.33%       89  IndexSet::insert(unsigned int)
[info]    860000000    1.29%       86  PhaseChaitin::elide_copy(Node*, int, Block*, Node_List&, Node_List&, bool)
[info]    790000000    1.18%       79  _platform_bzero$VARIANT$Haswell
[info]    730000000    1.09%       73  IndexSetIterator::next()
[info]    720000000    1.08%       72  __psynch_cvwait
[info]    690000000    1.03%       69  PhaseLive::compute(unsigned int)
[info]    680000000    1.02%       68  PhaseChaitin::post_allocate_copy_removal()
[info] # Run complete. Total time: 00:00:22
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                   (corpusPath)  (corpusVersion)  (extraArgs)  (resident)  (scalaVersion)  (source)    Mode  Cnt     Score      Error  Units
[info] HotScalacBenchmark.compile                     ../corpus          a8c43dc                    false         2.12.12    scalap  sample    6  1821.726 ± 1159.498  ms/op
[info] HotScalacBenchmark.compile:compile·p0.00       ../corpus          a8c43dc                    false         2.12.12    scalap  sample       1453.326             ms/op
[info] HotScalacBenchmark.compile:compile·p0.50       ../corpus          a8c43dc                    false         2.12.12    scalap  sample       1754.268             ms/op
[info] HotScalacBenchmark.compile:compile·p0.90       ../corpus          a8c43dc                    false         2.12.12    scalap  sample       2579.497             ms/op
[info] HotScalacBenchmark.compile:compile·p0.95       ../corpus          a8c43dc                    false         2.12.12    scalap  sample       2579.497             ms/op
[info] HotScalacBenchmark.compile:compile·p0.99       ../corpus          a8c43dc                    false         2.12.12    scalap  sample       2579.497             ms/op
[info] HotScalacBenchmark.compile:compile·p0.999      ../corpus          a8c43dc                    false         2.12.12    scalap  sample       2579.497             ms/op
[info] HotScalacBenchmark.compile:compile·p0.9999     ../corpus          a8c43dc                    false         2.12.12    scalap  sample       2579.497             ms/op
[info] HotScalacBenchmark.compile:compile·p1.00       ../corpus          a8c43dc                    false         2.12.12    scalap  sample       2579.497             ms/op
[info] HotScalacBenchmark.compile:·async              ../corpus          a8c43dc                    false         2.12.12    scalap  sample            NaN               ---
```

## Generate Flamegraph

```
-prof "async:file=/tmp/flame.svg;minwidth=2"
```

## Generate Java Flight Recorder output for allocations

```
-prof "async:file=/tmp/prof.jfr;event=alloc"
```


WIP for #1 